### PR TITLE
Minimal compatibility with CrateDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Enhanced
+- Tweaked PostgreSQL adapter for CrateDB compatibility
+
 ## [0.10.0] - 2024-12-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ tinyetl "https://api.data.gov/export.json" analysis.parquet
    *Note: Auto-inferred schemas default all columns to nullable for safety*
 
 ✅ **Lua transformations** — powerful data transformations  
-✅ **Universal connectivity** — CSV, JSON, Parquet, Avro, MySQL, PostgreSQL, SQLite, DuckDB, MSSQL, ODBC. Coming soon: Snowflake, Databricks, OneLake
+✅ **Universal connectivity** — CSV, JSON, Parquet, Avro, MySQL, PostgreSQL, SQLite, CrateDB, DuckDB, MSSQL, ODBC. Coming soon: Snowflake, Databricks, OneLake
 
 ✅ **Cross-platform** — Linux, macOS, Windows ready
 
@@ -250,6 +250,7 @@ TinyETL supports two main categories of data sources and targets:
 - **SQLite** - Embedded database
 - **PostgreSQL** - Advanced open-source database
 - **MySQL** - Popular relational database
+- **CrateDB** - Distributed analytical database optimized for OLAP workloads
 - **DuckDB** - Embedded analytical database optimized for OLAP workloads
 - **ODBC** - Universal database connectivity (SQL Server, Oracle, DB2, and more)
 
@@ -266,6 +267,10 @@ tinyetl data.csv "postgresql://user:@localhost/mydb#customers"
 # MySQL
 tinyetl "mysql://user:@localhost:3306/mydb#products" output.json
 tinyetl data.csv "mysql://user:@localhost:3306/mydb#sales"
+
+# CrateDB
+tinyetl "postgresql://crate:@localhost/doc#orders" output.parquet
+tinyetl data.csv "postgresql://crate:@localhost/doc#customers"
 
 # DuckDB
 tinyetl "products.duckdb#inventory" output.csv
@@ -342,6 +347,16 @@ tinyetl data.csv /path/to/database.db   # Creates table named 'database'
 tinyetl data.csv "sqlite:///path/to/database.db#custom_table"
 ```
 
+**CrateDB:**
+```bash
+# Basic format
+postgresql://username:password@hostname:port/schema#table_name
+
+# Examples
+tinyetl data.csv "postgresql://user:@localhost/doc#customers"
+tinyetl data.csv "postgresql://admin:@db.example.com:5432/analytics#sales_data"
+```
+
 **DuckDB:**
 ```bash
 # File path (table name inferred from filename without extension)
@@ -394,7 +409,7 @@ tinyetl data.csv "odbc://Driver={IBM DB2 ODBC DRIVER};Database=sample;Hostname=l
 - For MySQL and ODBC databases, the database must exist before running TinyETL
 - DuckDB is optimized for analytical (OLAP) workloads and offers better performance than SQLite for aggregations
 - Connection strings should be quoted to prevent shell interpretation
-- Default ports: PostgreSQL (5432), MySQL (3306)
+- Default ports: PostgreSQL (5432), CrateDB (5432), MySQL (3306)
 
 ### Secure Password Management
 
@@ -420,7 +435,7 @@ tinyetl "postgres://user@prod.example.com/db#orders" \
 - Format: `TINYETL_SECRET_{protocol}_{type}` or `TINYETL_SECRET_{protocol}`
 - Examples:
   - `TINYETL_SECRET_mysql_dest` - for MySQL destination connections
-  - `TINYETL_SECRET_postgres_source` - for PostgreSQL source connections  
+  - `TINYETL_SECRET_postgres_source` - for PostgreSQL and CrateDB source connections
   - `TINYETL_SECRET_mysql` - generic MySQL password (works for both source/dest)
 
 

--- a/src/connectors/postgres.rs
+++ b/src/connectors/postgres.rs
@@ -376,7 +376,7 @@ impl Target for PostgresTarget {
                 let pg_type = match col.data_type {
                     DataType::String => "TEXT",
                     DataType::Integer => "BIGINT",
-                    DataType::Decimal => "DECIMAL",
+                    DataType::Decimal => "DECIMAL(18,6)",
                     DataType::Boolean => "BOOLEAN",
                     DataType::Date | DataType::DateTime => "TIMESTAMP WITH TIME ZONE",
                     DataType::Json => "JSONB", // PostgreSQL native JSON type
@@ -507,7 +507,7 @@ impl Target for PostgresTarget {
             .ok_or_else(|| TinyEtlError::Connection("Not connected".to_string()))?;
 
         let exists_query =
-            "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $1)";
+            "SELECT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = $1)";
 
         let exists: bool = sqlx::query_scalar(exists_query)
             .bind(table_name)


### PR DESCRIPTION
Dear Alex,

thank you for conceiving this excellent project. CrateDB is PostgreSQL wire compatible, so we tried to give it a shot with TinyETL. We found the required adjustments are minimal, so there is a chance you might accept them into the PostgreSQL connector?

With kind regards,
Andreas.

#### References
We derived two reports from these insights, so future versions of CrateDB might be fully compatible. /cc @seut
- https://github.com/crate/crate/issues/18799
- https://github.com/crate/crate/issues/18800

#### Preview
```shell
cargo install --git https://github.com/crate-workbench/TinyETL.git --branch cratedb-compat -j default
```

#### Backlog
On a subsequent iteration, we will probably need to submit a dedicated connector for CrateDB: 13ae338 adds support for JSON-like data types, and CrateDB uses `OBJECT(DYNAMIC)` closest to that.
